### PR TITLE
Update validate-generate script to support python3

### DIFF
--- a/validate-generate
+++ b/validate-generate
@@ -16,11 +16,19 @@ import fontforge;
 font = fontforge.open("Sources/${basename}.sfd");
 
 # Extract interesting informations
-print font.fontname
-print font.familyname
-print font.fullname
-print font.os2_weight
-print font.italicangle
+$(if [[ "$(python --version 2>&1 | cut -d' ' -f2- | cut -c1)" == "3" ]]; then
+  echo 'print(font.fontname)'
+  echo 'print(font.familyname)'
+  echo 'print(font.fullname)'
+  echo 'print(font.os2_weight)'
+  echo 'print(font.italicangle)'
+else
+  echo 'print font.fontname'
+  echo 'print font.familyname'
+  echo 'print font.fullname'
+  echo 'print font.os2_weight'
+  echo 'print font.italicangle'
+fi)
 
 bitmask = font.validate();
 if bitmask != 0:


### PR DESCRIPTION
---

I had a (relatively brief) look to find out how to detect which version of python one's fontforge would use, but couldn't find an answer. So does it just use the system `python` binary?

Because if so, this might work, but if not, this is probably **not** the solution.

Also note I have not looked at the rest of the script or anything, and this is just a very rudimentary patch I made in 2 seconds, so I do not know if this breaks anything. But running `make` does work for me now, as opposed to before.