### PR TITLE
Port Fira Code's ligature logic

### DIFF
--- a/Scripts/features.py
+++ b/Scripts/features.py
@@ -53,6 +53,12 @@ def rule(liga):
         ignore(head=liga[0], suffix=(liga[1:] + [liga[-1]])),
     ]
 
+    # careful with repeats:
+    # #133 ->->->->, /**/**/**/, etc.
+    if len(liga) > 2 and liga[0] == liga[-1]:
+        rules.append(ignore([liga[-2]], liga[0], liga[1:]))
+        rules.append(ignore(head=liga[0], suffix=(liga[1:] + [liga[1]])))
+
     # hardcoded ignores, i.e. `<||>`
     rules.extend(ignores[tuple(liga)])
 

--- a/Scripts/features.py
+++ b/Scripts/features.py
@@ -59,6 +59,16 @@ def rule(liga):
         rules.append(ignore([liga[-2]], liga[0], liga[1:]))
         rules.append(ignore(head=liga[0], suffix=(liga[1:] + [liga[1]])))
 
+    # Don't cut into `prefix` to complete a ligature.
+    #  i.e. regex `(?=`>  is not `(?`=>.
+    rules.extend(
+        [
+            ignore(prefix[:-n], liga[0], liga[1:])
+            for prefix in ignore_prefixes
+            for n in range(1, len(liga))
+            if prefix[-n:] == liga[:n]
+        ]
+    )
     # hardcoded ignores, i.e. `<||>`
     rules.extend(ignores[tuple(liga)])
 
@@ -196,6 +206,18 @@ ignores = defaultdict(
         ("slash", "slash"): ["ignore sub colon slash' slash;"],
     },
 )
+
+
+ignore_prefixes = [
+    ["parenleft", "question", "colon"],
+    # Regexp lookahead/lookbehind
+    ["parenleft", "question", "equal"],
+    ["parenleft", "question", "less", "equal"],
+    ["parenleft", "question", "exclam"],
+    ["parenleft", "question", "less", "exclam"],
+    # PHP <?=
+    ["less", "question", "equal"],
+]
 
 
 def indent(text, prefix):

--- a/Scripts/features.py
+++ b/Scripts/features.py
@@ -44,36 +44,41 @@ def rule(liga):
                  [LIG   f i] LIG
                  [ f    f i] LIG }
     """
-    if len(liga) == 2:
-        return dedent('''\
-          lookup {0}_{1} {{
-            ignore sub {0} {0}' {1};
-            ignore sub {0}' {1} {1};
-            sub {0}'  {1}  by LIG;
-            sub LIG {1}' by {0}_{1}.liga;
-          }} {0}_{1};
-        ''').format(*liga)
-    elif len(liga) == 3:
-        return dedent('''\
-          lookup {0}_{1}_{2} {{
-            ignore sub {0} {0}' {1} {2};
-            ignore sub {0}' {1} {2} {2};
-            sub {0}' {1}  {2} by LIG;
-            sub LIG  {1}' {2} by LIG;
-            sub LIG  LIG  {2}' by {0}_{1}_{2}.liga;
-          }} {0}_{1}_{2};
-        ''').format(*liga)
-    elif len(liga) == 4:
-        return dedent('''\
-            lookup {0}_{1}_{2}_{3} {{
-               ignore sub {0} {0}' {1} {2} {3};
-               ignore sub {0}' {1} {2} {3} {3};
-               sub {0}'   {1}   {2}  {3}  by LIG;
-               sub LIG  {1}'  {2}  {3}  by LIG;
-               sub LIG LIG  {2}' {3}  by LIG;
-               sub LIG LIG LIG {3}' by {0}_{1}_{2}_{3}.liga;
-            }} {0}_{1}_{2}_{3};
-        ''').format(*liga)
+    # ignores:
+    #   ignore sub {0} {0}' {1};
+    #   ignore sub {0}' {1} {1};
+    rules = [
+        ignore(prefix=liga[:1], head=liga[0], suffix=liga[1:]),
+        ignore(head=liga[0], suffix=(liga[1:] + [liga[-1]])),
+    ]
+
+    name = "_".join(liga)
+    # substitution logic
+    #   sub {0}'  {1}  by LIG;
+    #   sub LIG {1}' by {0}_{1}.liga;
+    for i in range(len(liga)):
+        init = _join(["LIG" for lig in liga[:i]])
+        tail = _join(liga[i + 1 :])
+        replace = "LIG" if (i + 1 < len(liga)) else (name + ".liga")
+        rules.append("sub{0} {1}'{2} by {3};".format(init, liga[i], tail, replace))
+
+    # put it all together
+    lines = (
+        ["lookup " + name + " {"] + ["  " + r for r in rules] + ["}} {0};".format(name)]
+    )
+    return "\n".join(lines)
+
+
+def _join(items):
+    return (" " + " ".join(items)) if items else ""
+
+
+def ignore(prefix=None, head=None, suffix=None):
+    """ don't substitute `head` if it's surrounded by `prefix` and `suffix` """
+    assert head
+    pref = _join(prefix)
+    rest = _join(suffix)
+    return "ignore sub{0} {1}'{2};".format(pref, head, rest)
 
 
 def indent(text, prefix):

--- a/Scripts/features.py
+++ b/Scripts/features.py
@@ -45,13 +45,17 @@ def rule(liga):
                  [LIG   f i] LIG
                  [ f    f i] LIG }
     """
+    rules = []
     # standard ignores:
     #   ignore sub {0} {0}' {1};
     #   ignore sub {0}' {1} {1};
-    rules = [
-        ignore(prefix=liga[:1], head=liga[0], suffix=liga[1:]),
-        ignore(head=liga[0], suffix=(liga[1:] + [liga[-1]])),
-    ]
+    if tuple(liga) not in skip_ignores:
+        rules.extend(
+            [
+                ignore(prefix=liga[:1], head=liga[0], suffix=liga[1:]),
+                ignore(head=liga[0], suffix=(liga[1:] + [liga[-1]])),
+            ]
+        )
 
     # careful with repeats:
     # #133 ->->->->, /**/**/**/, etc.
@@ -218,6 +222,15 @@ ignore_prefixes = [
     # PHP <?=
     ["less", "question", "equal"],
 ]
+
+
+# DO NOT generate ignores at all
+skip_ignores = {
+    # # <<*>> <<+>> <<$>>
+    # ("less", "asterisk", "greater"),
+    # ("less", "plus", "greater"),
+    # ("less", "dollar", "greater"),
+}
 
 
 def indent(text, prefix):


### PR DESCRIPTION
This ports much of the logic from Fira Code into Fantasque Sans, correcting some ligature bugs that have been already noted, and preventing others in case of expansion.

It also allows for arbitrary-length ligatures. Simply add a properly formatted *.liga.glyph, and the python takes care of the rest. No more 4-char limit.

**I have not built this version.** My fontforge uses python3. I tried to make everything backwards compatible, but have not been able to verify that it builds. See my [main branch](https://github.com/claymager/fantasque-sans/tree/claymager) for a viable python3 version.

\*\* Btw, thanks for the great font. I've used it for years and love it.