### PR TITLE
Add build Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install software-properties-common -y && \
+    add-apt-repository ppa:fontforge/fontforge -y && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      fontforge \
+      woff-tools \
+      woff2 \
+      ttfautohint \
+      make \
+      zip
+
+WORKDIR /fantasque
+
+VOLUME /fantasque/Release
+
+COPY . /fantasque
+
+CMD ["make"]

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Alternatively, if you'd like to build Fantasque without installing required depe
 
 ```sh
 docker build -t fantasque .
-docker run -v `pwd`/Variants:/fantasque/Variants
+docker run -v `pwd`/Variants:/fantasque/Variants fantasque
 ```
 
 [![](Specimen/Specimen.png)](Specimen/Specimen.pdf)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ the latest prebuilt release of these fonts.
 `make install` will install the TTF fonts into your local `.fonts/` directory
 and update the font cache. It comes in handy while modifying the font.
 
+Alternatively, if you'd like to build Fantasque without installing required dependencies, a Dockerfile is provided. Run the following command, and the fonts will be built to the ./Variants directory.
+
+```sh
+docker build -t fantasque .
+docker run -v `pwd`/Variants:/fantasque/Variants
+```
+
 [![](Specimen/Specimen.png)](Specimen/Specimen.pdf)
 
 Webfonts


### PR DESCRIPTION
Hi 👋

Thank you for the font, I love using it for the terminal.

I added a Dockerfile to be able to build the font without installing the necessary deps. (I was struggling on MacOS) and thought I'd share if you are interested.

A note - while the files seem to build fine, FontForge is saying there are validation errors;

![image](https://user-images.githubusercontent.com/1167624/86324044-1ef1b880-bc68-11ea-90e9-96275e968d64.png)

I didn't feel like learning about what a bitmask is to find out about the errors but there are some of them apparently ¯\_(ツ)_/¯
