### PR TITLE
README.md - Update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ useful for users of accented capitals. For more info, see the [CHANGELOG](CHANGE
 Automatic installation on macOS with [homebrew](https://brew.sh):
 
     brew tap homebrew/cask-fonts #You only need to do this once for cask-fonts
-    brew cask install font-fantasque-sans-mono
+    brew install --cask font-fantasque-sans-mono
 
 Instructions for other platforms might follow.
 


### PR DESCRIPTION
Hello, when running this command: `brew cask install font-fantasque-sans-mono`  got this `Error: Calling brew cask install is disabled! Use brew install [--cask] instead.` this PR fix this.

- brew cask commands were disabled on 2020-12-21 with the release of Homebrew 2.7.0. Starting then, all brew cask commands failed and displayed a warning informing users that the command is disabled. The message also provides the appropriate replacement.
- With the release of Homebrew 2.8.0 (release date TBD), this disable message will be removed.