### PR TITLE
Make build scripts compatible with Python 3

### DIFF
--- a/Scripts/features.py
+++ b/Scripts/features.py
@@ -2,6 +2,8 @@
 #
 # Adapted from https://github.com/tonsky/FiraCode/blob/master/gen_calt.clj
 
+from __future__ import unicode_literals
+
 from textwrap import dedent
 from collections import defaultdict
 import tempfile
@@ -33,7 +35,7 @@ def update_features(font):
     # Add the dummy "LIG" glyph
     lig = font.createChar(-1, 'LIG')
     lig.width = font['space'].width
-    with tempfile.NamedTemporaryFile(suffix='.fea') as f:
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.fea') as f:
         f.write(fea_code)
         f.seek(0)
         font.mergeFeature(f.name)

--- a/Scripts/fontbuilder.py
+++ b/Scripts/fontbuilder.py
@@ -3,6 +3,8 @@
 # LICENSE: MIT
 # vim: sts=4 sw=4 ts=4 et
 
+from past.builtins import xrange
+
 import fontforge
 from itertools import compress
 import os


### PR DESCRIPTION
Since newer versions of FontForge use Python 3, I figured it would be nice to make the build scripts compatible.  Python 2 compatibility should be unaffected.