### PR TITLE
Inline some helpers from six for python3 buildability

### DIFF
--- a/Scripts/features.py
+++ b/Scripts/features.py
@@ -4,7 +4,22 @@
 
 from textwrap import dedent
 import tempfile
+import sys
 
+PY3 = sys.version_info[0] == 3
+if PY3:
+    binary_type = bytes
+    text_type = str
+else:
+    binary_type = str
+    text_type = unicode
+
+def ensure_binary(s, encoding='utf-8', errors='strict'):
+    if isinstance(s, binary_type):
+        return s
+    if isinstance(s, text_type):
+        return s.encode(encoding, errors)
+    raise TypeError("not expecting type '%s'" % type(s))
 
 def update_features(font):
     """Find ligatures in the font and generate features for them."""
@@ -26,6 +41,7 @@ def update_features(font):
         {}
         }} calt;
     ''').format(indent(rules, '  '))
+    fea_code = ensure_binary(fea_code)
 
     # print(fea_code)  # DEBUG
 

--- a/Scripts/fontbuilder.py
+++ b/Scripts/fontbuilder.py
@@ -9,6 +9,11 @@ import os
 from os.path import basename, splitext, join
 import subprocess
 from features import update_features
+import sys
+
+PY3 = sys.version_info[0] == 3
+if PY3:
+    xrange = range
 
 SCRIPTS = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Alternative to #142

Also, using this, i'm able to get the fonts to build on macOS, via

```
brew tap bramstein/webfonttools
brew install fontforge ttfautohint woff2 sfnt2woff
```