### PR TITLE
Build: fix range error for missing module 'past'

### DIFF
--- a/Scripts/fontbuilder.py
+++ b/Scripts/fontbuilder.py
@@ -3,8 +3,6 @@
 # LICENSE: MIT
 # vim: sts=4 sw=4 ts=4 et
 
-from past.builtins import xrange
-
 import fontforge
 from itertools import compress
 import os
@@ -72,9 +70,9 @@ def permutations():
     bitmap_max = 1 << count
 
     # Iterate over all possible permutations
-    for i in xrange(bitmap_max):
+    for i in range(bitmap_max):
         # Map the iteration's permutations using a bitmap
-        bitmap = [i >> n & 1 for n in xrange(count)]
+        bitmap = [i >> n & 1 for n in range(count)]
         for opts in _expand_options(bitmap):
             yield(int(float(i)/bitmap_max*100), opts)
 


### PR DESCRIPTION
On systems without `future`, there would issues with missing `past`.

        from past.builtins import xrange
    ModuleNotFoundError: No module named 'past'

Installing `future` like `pip install future` can help, but it bothers.

Changing `xrange` to `range` can be OK since python3 has no `xrange` anymore, while both 2 and 3 can have `range`.

The performance impact with python2 should be minor.

Tested OK on latest Debian bullseye/bookworm, Ubuntu jammy, and Archlinux, with python2 linked to 2.7.18, or 2.7.3, while python linked to 3.10.8, 3.10.6, or 3.9.2.