### PR TITLE
Fix: remove deprecated homebrew/cask-fonts tap from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ useful for users of accented capitals. For more info, see the [CHANGELOG](CHANGE
 
 Automatic installation on macOS with [homebrew](https://brew.sh):
 
-    brew tap homebrew/cask-fonts #You only need to do this once for cask-fonts
     brew install --cask font-fantasque-sans-mono
 
 Instructions for other platforms might follow.


### PR DESCRIPTION
The `homebrew/cask-fonts` tap has been deprecated and is no longer needed, all fonts were migrated into the main [`homebrew/homebrew-cask`](https://github.com/Homebrew/homebrew-cask) repository.

Running `brew tap homebrew/cask-fonts` now produces:

```
Error: homebrew/cask-fonts was deprecated.
This tap is now empty and all its contents were either deleted or migrated.
```

This PR removes the outdated tap step, leaving only the correct install command.

References:
- [homebrew/cask-fonts deprecation](https://github.com/orgs/Homebrew/discussions/6213#discussioncomment-13443393)
- [Homebrew Formulae](https://formulae.brew.sh/cask/font-fantasque-sans-mono)